### PR TITLE
fix: match the name

### DIFF
--- a/pages/staking.staking.tsx
+++ b/pages/staking.staking.tsx
@@ -150,12 +150,12 @@ export default function Staking() {
                   stakeData={stakeGeneralResult?.pegasys}
                   stakeUserData={stakeUserResult?.pegasys}
                   ethPriceUsd={stakeGeneralResult?.ethPriceUsd}
-                  onStakeAction={() => openStake('psys', 'PSYS')}
-                  onCooldownAction={() => openStakeCooldown('psys')}
-                  onUnstakeAction={() => openUnstake('psys', 'PSYS')}
-                  onStakeRewardClaimAction={() => openStakeRewardsClaim('psys', 'PSYS')}
+                  onStakeAction={() => openStake('pegasys', 'PSYS')}
+                  onCooldownAction={() => openStakeCooldown('pegasys')}
+                  onUnstakeAction={() => openUnstake('pegasys', 'PSYS')}
+                  onStakeRewardClaimAction={() => openStakeRewardsClaim('pegasys', 'PSYS')}
                   onStakeRewardClaimRestakeAction={() =>
-                    openStakeRewardsRestakeClaim('psys', 'PSYS')
+                    openStakeRewardsRestakeClaim('pegasys', 'PSYS')
                   }
                   headerAction={<BuyWithFiat cryptoSymbol="PSYS" networkMarketName={network} />}
                   hasDiscountProgram={true}

--- a/src/modules/staking/StakingPanel.tsx
+++ b/src/modules/staking/StakingPanel.tsx
@@ -140,13 +140,14 @@ export const StakingPanel: React.FC<StakingPanelProps> = ({
       .mul(ethPriceUsd || '1'),
     18 + 18 + 8 // incentivesBalance (18), rewardTokenPriceEth (18), ethPriceUsd (8)
   );
-
   const aavePerMonth = formatEther(
-    valueToBigNumber(stakeUserData?.stakeTokenRedeemableAmount || '0')
-      .dividedBy(stakeData?.stakeTokenTotalSupply || '1')
-      .multipliedBy(stakeData?.distributionPerSecond || '0')
-      .multipliedBy('2592000')
-      .toFixed(0)
+    stakeData?.stakeTokenTotalSupply === '0'
+      ? 0
+      : valueToBigNumber(stakeUserData?.stakeTokenRedeemableAmount || '0')
+          .dividedBy(stakeData?.stakeTokenTotalSupply || '1')
+          .multipliedBy(stakeData?.distributionPerSecond || '0')
+          .multipliedBy('2592000')
+          .toFixed(0)
   );
 
   return (


### PR DESCRIPTION
## General Changes

Fixed an error that resulted in NaN (Not a Number). The 'stakeTokenTotalSupply' value was 0, which occurred when there were no staked tokens.
Corrected the 'stakeAssetName' to match the correct asset, resolving the issue where it previously matched 'Pegasys' incorrectly.